### PR TITLE
feat: add Azure OpenAI validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ cookie](https://github.com/ripperhe/Bob/issues/115)。
 2、`欧路词典` 是通过开放 api 添加到指导单词本，但是需要指定单词本的 id，可以通过 api 获取单词本 id。
 
 3、`扇贝单词` 是通过 api 添加到指导单词本，需要登录后从网页获取 auth_token
+4、新增可选的 Azure OpenAI 检测，填写 Azure API Key、Endpoint、Deployment Name 与 Model 后，只有当模型判断文本为有效英文单词时才会添加到单词本，避免邮箱或姓名等无效内容。
 ## 设置
 
 ![](imgs/1.png)

--- a/src/info.json
+++ b/src/info.json
@@ -57,6 +57,42 @@
       ]
     },
     {
+      "identifier": "azure_api_key",
+      "type": "text",
+      "title": "Azure API Key",
+      "textConfig": {
+        "type": "secure",
+        "placeholderText": "输入 Azure OpenAI API Key"
+      }
+    },
+    {
+      "identifier": "azure_endpoint",
+      "type": "text",
+      "title": "Azure Endpoint",
+      "textConfig": {
+        "type": "visible",
+        "placeholderText": "例如 https://xxx.openai.azure.com"
+      }
+    },
+    {
+      "identifier": "azure_deployment_name",
+      "type": "text",
+      "title": "Deployment Name",
+      "textConfig": {
+        "type": "visible",
+        "placeholderText": "Azure OpenAI 部署名称"
+      }
+    },
+    {
+      "identifier": "azure_model",
+      "type": "text",
+      "title": "Model",
+      "textConfig": {
+        "type": "visible",
+        "placeholderText": "模型名称"
+      }
+    },
+    {
       "identifier": "wordbook_id",
       "type": "text",
       "title": "欧路单词本 id",


### PR DESCRIPTION
## Summary
- add optional Azure OpenAI validation to ensure only real English words are saved
- expose Azure OpenAI API key, endpoint, deployment name and model options
- document the new LLM filter in README

## Testing
- `node -e "new Function(require('fs').readFileSync('src/main.js','utf8')); console.log('syntax ok')"`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a08b693b388321bcec3a1db77af8f6