### PR TITLE
feat: add volcano inference option

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ cookie](https://github.com/ripperhe/Bob/issues/115)。
 
 3、`扇贝单词` 是通过 api 添加到指导单词本，需要登录后从网页获取 auth_token
 4、新增可选的 Azure OpenAI 检测，填写 Azure API Key、Endpoint、Deployment Name 与 Model 后，只有当模型判断文本为有效英文单词时才会添加到单词本，避免邮箱或姓名等无效内容。
+5、支持在 Azure OpenAI 与火山引擎之间选择校验服务，可自定义系统提示词并默认关闭思考模式以获得更快响应。
 ## 设置
 
 ![](imgs/1.png)

--- a/src/info.json
+++ b/src/info.json
@@ -57,6 +57,31 @@
       ]
     },
     {
+      "identifier": "llm_provider",
+      "type": "menu",
+      "title": "LLM 服务",
+      "defaultValue": "azure",
+      "menuValues": [
+        {
+          "title": "OpenAI Azure",
+          "value": "azure"
+        },
+        {
+          "title": "火山引擎",
+          "value": "volcano"
+        }
+      ]
+    },
+    {
+      "identifier": "llm_system_prompt",
+      "type": "text",
+      "title": "系统提示词",
+      "textConfig": {
+        "type": "visible",
+        "placeholderText": "自定义系统提示词"
+      }
+    },
+    {
       "identifier": "azure_api_key",
       "type": "text",
       "title": "Azure API Key",
@@ -87,6 +112,33 @@
       "identifier": "azure_model",
       "type": "text",
       "title": "Model",
+      "textConfig": {
+        "type": "visible",
+        "placeholderText": "模型名称"
+      }
+    },
+    {
+      "identifier": "volcano_api_key",
+      "type": "text",
+      "title": "火山 API Key",
+      "textConfig": {
+        "type": "secure",
+        "placeholderText": "输入火山引擎 API Key"
+      }
+    },
+    {
+      "identifier": "volcano_endpoint",
+      "type": "text",
+      "title": "火山 Endpoint",
+      "textConfig": {
+        "type": "visible",
+        "placeholderText": "例如 https://ark.cn-beijing.volces.com/api/v3"
+      }
+    },
+    {
+      "identifier": "volcano_model",
+      "type": "text",
+      "title": "火山模型",
       "textConfig": {
         "type": "visible",
         "placeholderText": "模型名称"

--- a/src/main.js
+++ b/src/main.js
@@ -224,37 +224,75 @@ function addWordShanbay(token, word, completion) {
 }
 
 function checkWordByLLM(word, callback) {
-    var api_key = $option.azure_api_key;
-    var endpoint = $option.azure_endpoint;
-    var deployment = $option.azure_deployment_name;
-    var model = $option.azure_model;
-    if (!(api_key && endpoint && deployment && model)) {
-        callback(true);
-        return;
-    }
-    var url = endpoint + "/openai/deployments/" + deployment + "/chat/completions?api-version=2023-07-01-preview";
-    $http.post({
-        url: url,
-        header: {
-            "api-key": api_key,
-            "Content-Type": "application/json"
-        },
-        body: {
-            "model": model,
-            "messages": [
-                {"role": "system", "content": "You are a service that checks if the text is a valid English word. Reply only with Yes or No."},
-                {"role": "user", "content": word}
-            ],
-            "max_tokens": 1,
-            "temperature": 0
-        },
-        handler: function(res) {
-            try {
-                var answer = res.data.choices[0].message.content.trim();
-                callback(answer === 'Yes');
-            } catch (e) {
-                callback(false);
-            }
+    var provider = $option.llm_provider;
+    var systemPrompt = $option.llm_system_prompt || "You are a service that checks if the text is a valid English word. Reply only with Yes or No.";
+    if (provider === 'volcano') {
+        var vApiKey = $option.volcano_api_key;
+        var vEndpoint = $option.volcano_endpoint;
+        var vModel = $option.volcano_model;
+        if (!(vApiKey && vEndpoint && vModel)) {
+            callback(true);
+            return;
         }
-    });
+        var vUrl = vEndpoint + "/chat/completions";
+        $http.post({
+            url: vUrl,
+            header: {
+                "Authorization": "Bearer " + vApiKey,
+                "Content-Type": "application/json"
+            },
+            body: {
+                "model": vModel,
+                "messages": [
+                    {"role": "system", "content": systemPrompt},
+                    {"role": "user", "content": word}
+                ],
+                "max_tokens": 1,
+                "temperature": 0,
+                "extra": {"with_thinking": false}
+            },
+            handler: function(res) {
+                try {
+                    var answer = res.data.choices[0].message.content.trim();
+                    callback(answer === 'Yes');
+                } catch (e) {
+                    callback(false);
+                }
+            }
+        });
+    } else {
+        var api_key = $option.azure_api_key;
+        var endpoint = $option.azure_endpoint;
+        var deployment = $option.azure_deployment_name;
+        var model = $option.azure_model;
+        if (!(api_key && endpoint && deployment && model)) {
+            callback(true);
+            return;
+        }
+        var url = endpoint + "/openai/deployments/" + deployment + "/chat/completions?api-version=2023-07-01-preview";
+        $http.post({
+            url: url,
+            header: {
+                "api-key": api_key,
+                "Content-Type": "application/json"
+            },
+            body: {
+                "model": model,
+                "messages": [
+                    {"role": "system", "content": systemPrompt},
+                    {"role": "user", "content": word}
+                ],
+                "max_tokens": 1,
+                "temperature": 0
+            },
+            handler: function(res) {
+                try {
+                    var answer = res.data.choices[0].message.content.trim();
+                    callback(answer === 'Yes');
+                } catch (e) {
+                    callback(false);
+                }
+            }
+        });
+    }
 }


### PR DESCRIPTION
## Summary
- allow choosing Azure OpenAI or Volcano engine for word validation
- support custom system prompts with thinking disabled by default for faster responses
- document new LLM service selection

## Testing
- `node --check src/main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a092b13e6c8321b2f8a56fb6e2a38a